### PR TITLE
Handle legit 404

### DIFF
--- a/wikihow2zim/constants.py
+++ b/wikihow2zim/constants.py
@@ -11,6 +11,7 @@ from zimscraperlib.i18n import get_language_details
 ROOT_DIR = pathlib.Path(__file__).parent
 NAME = ROOT_DIR.name
 DEFAULT_HOMEPAGE = "Main-Page"
+MAX_HTTP_404_THRESHOLD = 200
 
 with open(ROOT_DIR.joinpath("VERSION"), "r") as fh:
     VERSION = fh.read().strip()

--- a/wikihow2zim/utils.py
+++ b/wikihow2zim/utils.py
@@ -72,6 +72,21 @@ def cat_ident_for(href: str) -> str:
     return normalize_ident(href.split(":", 1)[1])
 
 
+def fix_pagination_links(soup: bs4.element.Tag):
+    """Replace ?pg= to _pg= in pagination links"""
+    for a in soup.select("#large_pagination a[href]"):
+        a["href"] = a["href"].replace("?pg=", "_pg=")
+
+
+def get_subcategories_from(soup: bs4.element.Tag, recurse: bool) -> List[str]:
+    """sub-categories urls from a category soup"""
+    if recurse:
+        return [
+            cat_ident_for(link.attrs["href"])
+            for link in soup.select("div#subcats * a.cat_link")
+        ]
+
+
 def normalize_ident(ident: str) -> str:
     """URL-decoded category identifier"""
     return urllib.parse.unquote(ident)


### PR DESCRIPTION
Fixes #43

- remove link from category page should we failed to scrape
- Print a log indicating the URL/article that was removed
- Keep a set of missing URLs
- Indicate number of missing articles in end-of-scrape stats
- Crash should it exceed a certain threshold (50 for now?)