### PR TITLE
--only filter

### DIFF
--- a/wikihow2zim/constants.py
+++ b/wikihow2zim/constants.py
@@ -79,6 +79,7 @@ class Conf:
     without_videos: Optional[bool] = False
     without_external_links: Optional[bool] = False
     exclude: Optional[str] = ""
+    only: Optional[str] = ""
     low_quality: Optional[bool] = False
     video_format: Optional[str] = "webm"
 

--- a/wikihow2zim/entrypoint.py
+++ b/wikihow2zim/entrypoint.py
@@ -116,6 +116,13 @@ def main():
     )
 
     parser.add_argument(
+        "--only",
+        help="Path or URL to a text file listing Article IDs to include in the scrape. "
+        "This filters out every other article. Lines starting with # are ignored",
+        dest="only",
+    )
+
+    parser.add_argument(
         "--optimization-cache",
         help="URL with credentials to S3 for using as optimization cache",
         dest="s3_url_with_credentials",


### PR DESCRIPTION
To be used in conjonction with a single category, an --only param allows pointing to
a list of Articles to include only.

All found articles, scraping that category are only included if in the list.

This “positive list” allows removing related links in articles that are not in the list.