### PR TITLE
Scrape using pre-populated expected lists computed through API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# 1.0.3
+# 1.1.0
 
 - Fixed parent-categories retrieval for root categories
 - Fixed category page icon size (#106)
+- Now works off an expected list of articles/categories
 
 # 1.0.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ six>=1.16.0,<2.0  # css-beautify dependency
 kiwixstorage>=0.8.1,<0.9
 pif>=0.8.2,<0.9
 tld>=0.12.6,<0.13
+pywikiapi>=4.3.0,<4.4

--- a/wikihow2zim/constants.py
+++ b/wikihow2zim/constants.py
@@ -4,7 +4,7 @@ import pathlib
 import tempfile
 import urllib.parse
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Set
 
 from zimscraperlib.i18n import get_language_details
 
@@ -84,7 +84,7 @@ class Conf:
     video_format: Optional[str] = "webm"
 
     # debug/devel
-    categories: List[str] = field(default_factory=list)
+    categories: Set[str] = field(default_factory=set)
     build_dir_is_tmp_dir: Optional[bool] = False
     keep_build_dir: Optional[bool] = False
     debug: Optional[bool] = False
@@ -94,6 +94,7 @@ class Conf:
     skip_footer_links: Optional[bool] = False
     skip_relateds: Optional[bool] = False
     single_article: Optional[str] = ""
+    full_mode: Optional[bool] = False
 
     @staticmethod
     def get_url(lang_code):
@@ -133,3 +134,5 @@ class Conf:
                 if ";" in tag:
                     self.tag += [p.strip() for p in tag.split(";")]
                     self.tag.remove(tag)
+
+        self.full_mode = not self.categories and not self.only and not self.exclude

--- a/wikihow2zim/shared.py
+++ b/wikihow2zim/shared.py
@@ -31,6 +31,13 @@ class Global:
     rewriter = None
     lock = threading.Lock()
 
+    exclusion_articles = set()
+    exclusion_categories = set()
+    inclusion_list = set()
+
+    expected_articles = set()
+    expected_categories = set()
+
     @staticmethod
     def set_debug(value):
         Global.debug = value
@@ -126,6 +133,26 @@ class GlobalMixin:
     @property
     def rewriter(self):
         return Global.rewriter
+
+    @property
+    def inclusion_list(self):
+        return Global.inclusion_list
+
+    @property
+    def exclusion_articles(self):
+        return Global.exclusion_articles
+
+    @property
+    def exclusion_categories(self):
+        return Global.exclusion_categories
+
+    @property
+    def expected_articles(self):
+        return Global.expected_articles
+
+    @property
+    def expected_categories(self):
+        return Global.expected_categories
 
 
 logger = Global.logger


### PR DESCRIPTION
- build an expected_articles list/set using MW API, based on requested categories, --only and --exclude.
- Skip articles scraping for those not in the list
- Update rewriter to work off this new list instead of the current combination of options
- Update scrape_category_page to work with the new list
- remove cards instead of link target
- Update breadcrumb rewriting to work off the list

Fixes #114